### PR TITLE
Accept optional canvas to avoid calling document.createElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Checks whether browser supports webgl
 # usage
 
 ```
-var webglEnabled = requrire('webgl-enabled')();
+var webglEnabled = require('webgl-enabled')();
 if (webglEnabled) {
   // yes, webgl is enabled
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-module.exports = function webglEnabled() {
+module.exports = function webglEnabled(canvas) {
   try {
-    var canvas = document.createElement('canvas');
-    return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+    if (!window.WebGLRenderingContext) return false;
+    if (!canvas) canvas = document.createElement('canvas');
+    return !!(canvas.getContext('webgl') || canvas.getContext('experimental-webgl'));
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
Don't create canvas if window.WebGLRenderingContext is false

Removing !! from the return statement would allow true-returned to be the context itself
